### PR TITLE
Attempt to download template if not in map

### DIFF
--- a/src/modules/init/index.js
+++ b/src/modules/init/index.js
@@ -6,18 +6,23 @@ import unzipTemplate from './unzipTemplate';
 import removeTemplate from './removeTemplate';
 
 const init = async (template = 'init') => {
-  const tmpPath = path.join(process.cwd(), 'tmp');
-  const downloadedTemplatePath = await downloadTemplate(
-    templates[template],
-    tmpPath,
-  );
-  const [{ path: unzippedTemplatePath }] = await unzipTemplate(
-    downloadedTemplatePath,
-    tmpPath,
-  );
-  await copyTemplate(path.join(tmpPath, unzippedTemplatePath), process.cwd());
-  await removeTemplate(tmpPath);
-  return true;
+  try {
+    const tmpPath = path.join(process.cwd(), 'tmp');
+    const downloadedTemplatePath = await downloadTemplate(
+      template in templates ? templates[template] : template,
+      tmpPath,
+    );
+    const [{ path: unzippedTemplatePath }] = await unzipTemplate(
+      downloadedTemplatePath,
+      tmpPath,
+    );
+    await copyTemplate(path.join(tmpPath, unzippedTemplatePath), process.cwd());
+    await removeTemplate(tmpPath);
+    return true;
+  } catch (err) {
+    console.log('Invalid template or URL provided');
+    return false;
+  }
 };
 
 export default init;


### PR DESCRIPTION
# Description

Init module entry function will now attempt to download the template from provided `template` argument as URL if no built-in template matches.   If the download fails it will let the user know.

Fixes #3 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
