### PR TITLE
options available when key is an array

### DIFF
--- a/src/modules/build/processTemplates.js
+++ b/src/modules/build/processTemplates.js
@@ -44,7 +44,7 @@ const buildFile = async (template, scope, options) => {
 const processTemplate = async (template, data, options) => {
   const scope = template.key ? objectGetDeep(data, template.key) : data;
   if (Array.isArray(scope)) {
-    scope.forEach((subscope) => buildFile(template, subscope));
+    scope.forEach((subscope) => buildFile(template, subscope, options));
   } else {
     buildFile(template, scope, options);
   }


### PR DESCRIPTION
# Description

When dynamically naming files, send a key and that key returns an array, the handlebars helpers do not work.

Fixes # 10